### PR TITLE
Add Profiling

### DIFF
--- a/Lavendel/CMakeLists.txt
+++ b/Lavendel/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(Lavendel SHARED
         "src/Lavendel/ImGui/ImGuiRenderer.cpp"
         "src/Lavendel/ImGui/Widgets/DemoWidget.h"
         "src/Lavendel/ImGui/Widgets/DemoWidget.cpp"
-        "src/Lavendel/Core/Profiling/Instrumentor.h"
+        "src/Lavendel/Utils/Profiling/Instrumentor.h"
 )
 
 if(WIN32)

--- a/Lavendel/src/Lavendel/Entrypoint.h
+++ b/Lavendel/src/Lavendel/Entrypoint.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "lvpch.h"
 #include "Log.h"
 
 
@@ -8,15 +9,21 @@ extern Lavendel::Application* Lavendel::CreateApplication();
 int main(int argc, char** argv)
 {
 	
+
 	Lavendel::Log::Init();
 
 	LV_CORE_INFO("Core Log Initialized!");
 	LV_INFO("Client Log Initialized!");
 
-
+	LV_PROFILE_BEGIN_SESSION("Startup", "LavendelProfile-Startup.json");
 	auto app = Lavendel::CreateApplication();
+	LV_PROFILE_END_SESSION();
+	LV_PROFILE_BEGIN_SESSION("Runtime", "LavendelProfile-Runtime.json");
 	app->Run();
+	LV_PROFILE_END_SESSION();
+	LV_PROFILE_BEGIN_SESSION("Shutdown", "LavendelProfile-Shutdown.json");
 	delete app;
+	LV_PROFILE_END_SESSION();
 }
 
 /*

--- a/Lavendel/src/Lavendel/ImGui/ImGuiLayer.cpp
+++ b/Lavendel/src/Lavendel/ImGui/ImGuiLayer.cpp
@@ -15,16 +15,19 @@ namespace Lavendel {
 	
 	ImGuiLayer::ImGuiLayer()
 	{
+		LV_PROFILE_FUNCTION();
 	}
 
 	ImGuiLayer::~ImGuiLayer()
 	{
+		LV_PROFILE_FUNCTION();
 		if (m_Renderer)
 			m_Renderer->Shutdown();
 	}
 
 	void ImGuiLayer::OnAttach()
 	{
+		LV_PROFILE_FUNCTION();
 		// Use static accessors from Renderer to get device and swapchain
 		auto swapchain = Lavendel::RenderAPI::Renderer::getSwapChain();
 		auto device = Lavendel::RenderAPI::Renderer::getDevice();
@@ -61,6 +64,7 @@ namespace Lavendel {
 
 	void ImGuiLayer::OnDetach()
 	{
+		LV_PROFILE_FUNCTION();
 		if (m_Renderer)
 			m_Renderer->Shutdown();
 		ImGui::DestroyContext();
@@ -69,6 +73,7 @@ namespace Lavendel {
 
 	void ImGuiLayer::OnEvent(Event& event)
 	{
+		LV_PROFILE_FUNCTION();
 		// Handle ImGui input events forwarded from Application via engine Events.
 		ImGuiIO& io = ImGui::GetIO(); (void)io;
 		// We rely on the SDL backend to process raw SDL events; engine Events may be
@@ -77,12 +82,14 @@ namespace Lavendel {
 
 	void ImGuiLayer::ProcessSDLEvent(const SDL_Event* event)
 	{
+		LV_PROFILE_FUNCTION();
 		// Forward raw SDL event to ImGui SDL3 backend
 		ImGui_ImplSDL3_ProcessEvent(reinterpret_cast<SDL_Event*>(const_cast<SDL_Event*>(event)));
 	}
 
 	void ImGuiLayer::OnUpdate()
 	{
+		LV_PROFILE_FUNCTION();
 		// Begin ImGui frame
 		m_Renderer->Begin();
 
@@ -95,6 +102,7 @@ namespace Lavendel {
 
 	void ImGuiLayer::OnRender(void* commandBuffer)
 	{
+		LV_PROFILE_FUNCTION();
 		// This method is called during the rendering phase after all scene geometry has been rendered.
 		// It takes the VkCommandBuffer that was passed through the layer system and renders the ImGui
 		// draw data that was prepared in OnUpdate(). This ensures ImGui renders on top of everything
@@ -102,6 +110,7 @@ namespace Lavendel {
 		
 		if (commandBuffer != nullptr)
 		{
+			LV_PROFILE_SCOPE("ImGuiLayer::OnRender Render");
 			VkCommandBuffer cmd = reinterpret_cast<VkCommandBuffer>(commandBuffer);
 			m_Renderer->Render(cmd);
 		}
@@ -109,11 +118,13 @@ namespace Lavendel {
 
 	void ImGuiLayer::Begin()
 	{
+		LV_PROFILE_FUNCTION();
 		m_Renderer->Begin();
 	}
 
 	void ImGuiLayer::End()
 	{
+		LV_PROFILE_FUNCTION();
 		m_Renderer->End();
 	}
 }

--- a/Lavendel/src/Lavendel/ImGui/ImGuiLayer.h
+++ b/Lavendel/src/Lavendel/ImGui/ImGuiLayer.h
@@ -12,7 +12,7 @@ struct SDL_Window;
 union SDL_Event;
 
 namespace Lavendel {
-	class ImGuiLayer : public Layer
+	class LAVENDEL_API ImGuiLayer : public Layer
 	{
 	public:
 		ImGuiLayer();

--- a/Lavendel/src/Lavendel/ImGui/ImGuiRenderer.cpp
+++ b/Lavendel/src/Lavendel/ImGui/ImGuiRenderer.cpp
@@ -9,10 +9,12 @@ namespace Lavendel {
 	ImGuiRenderer::ImGuiRenderer(std::shared_ptr<RenderAPI::SwapChain> swapchain, std::shared_ptr<RenderAPI::GPUDevice> device, SDL_Window* window)
 		: m_Swapchain(swapchain), m_Device(device), m_Window(window)
 	{
+		LV_PROFILE_FUNCTION();
 	}
 
 	void ImGuiRenderer::Init()
 	{
+		LV_PROFILE_FUNCTION();
 
 		// Initialize ImGui SDL3 backend first
 		if (!ImGui_ImplSDL3_InitForVulkan(m_Window))
@@ -75,6 +77,7 @@ namespace Lavendel {
 
 	void ImGuiRenderer::Shutdown()
 	{
+		LV_PROFILE_FUNCTION();
 		ImGui_ImplVulkan_Shutdown();
 		ImGui_ImplSDL3_Shutdown();
 		
@@ -90,6 +93,7 @@ namespace Lavendel {
 
 	void ImGuiRenderer::Begin()
 	{
+		LV_PROFILE_FUNCTION();
 		ImGui_ImplSDL3_NewFrame();
 		ImGui_ImplVulkan_NewFrame();
 		ImGui::NewFrame();
@@ -97,11 +101,13 @@ namespace Lavendel {
 
 	void ImGuiRenderer::End()
 	{
+		LV_PROFILE_FUNCTION();
 		ImGui::Render();
 	}
 
 	void ImGuiRenderer::Render(VkCommandBuffer& commandBuffer)
 	{
+		LV_PROFILE_FUNCTION();
 		ImDrawData* draw_data = ImGui::GetDrawData();
 		if (draw_data != nullptr)
 		{

--- a/Lavendel/src/Lavendel/ImGui/ImGuiRenderer.h
+++ b/Lavendel/src/Lavendel/ImGui/ImGuiRenderer.h
@@ -18,7 +18,7 @@ struct VkRenderPass_T;
 struct VkFramebuffer_T;
 
 namespace Lavendel {
-	class ImGuiRenderer {
+	class LAVENDEL_API ImGuiRenderer {
 	public:
 		ImGuiRenderer(std::shared_ptr<RenderAPI::SwapChain> swapchain, std::shared_ptr<RenderAPI::GPUDevice> device, SDL_Window* window);
 		~ImGuiRenderer() = default;

--- a/Lavendel/src/Lavendel/ImGui/Widgets/DemoWidget.cpp
+++ b/Lavendel/src/Lavendel/ImGui/Widgets/DemoWidget.cpp
@@ -5,15 +5,18 @@ namespace Lavendel {
 	DemoWidget::DemoWidget(const std::string& name)
 		: m_Name(name)
 	{
+		LV_PROFILE_FUNCTION();
 	}
 
 	void DemoWidget::OnRender()
 	{
+		LV_PROFILE_FUNCTION();
 		if (!m_IsVisible)
 			return;
 
 		if (ImGui::Begin(m_Name.c_str(), &m_IsVisible, ImGuiWindowFlags_AlwaysAutoResize))
 		{
+			LV_PROFILE_SCOPE("DemoWidget::OnRender UI");
 			ImGui::Text("Hello from Lavendel ImGui Demo Widget!");
 			ImGui::Separator();
 

--- a/Lavendel/src/Lavendel/ImGui/Widgets/DemoWidget.h
+++ b/Lavendel/src/Lavendel/ImGui/Widgets/DemoWidget.h
@@ -4,7 +4,7 @@
 #include <string>
 
 namespace Lavendel {
-	class DemoWidget {
+	class LAVENDEL_API DemoWidget {
 	public:
 		DemoWidget(const std::string& name = "Demo Widget");
 		~DemoWidget() = default;

--- a/Lavendel/src/Lavendel/Layers/Layer.cpp
+++ b/Lavendel/src/Lavendel/Layers/Layer.cpp
@@ -10,11 +10,11 @@ namespace Lavendel
 {
     Layer::Layer(const std::string& debugName) : m_DebugName(debugName)
     {
-
+        LV_PROFILE_FUNCTION();
     }
 
     Layer::~Layer()
     {
-
+        LV_PROFILE_FUNCTION();
     }
 }

--- a/Lavendel/src/Lavendel/Layers/LayerStack.cpp
+++ b/Lavendel/src/Lavendel/Layers/LayerStack.cpp
@@ -9,10 +9,12 @@ namespace Lavendel
 {
     LayerStack::LayerStack() : m_LayerInsertIndex(0)
     {
+        LV_PROFILE_FUNCTION();
     }
 
     LayerStack::~LayerStack()
     {
+        LV_PROFILE_FUNCTION();
         for (Layer* layer : m_Layers)
         {
             delete layer;
@@ -21,6 +23,7 @@ namespace Lavendel
 
     void LayerStack::PushLayer(Layer* layer)
     {
+        LV_PROFILE_FUNCTION();
         m_LayerInsertIndex = m_Layers.emplace(m_Layers.begin() + m_LayerInsertIndex, layer) - m_Layers.begin();
         ++m_LayerInsertIndex;
         layer->OnAttach();
@@ -28,12 +31,14 @@ namespace Lavendel
 
     void LayerStack::PushOverlay(Layer* overlay)
     {
+        LV_PROFILE_FUNCTION();
         m_Layers.emplace_back(overlay);
         overlay->OnAttach();
     }
 
     void LayerStack::PopLayer(Layer* layer)
     {
+        LV_PROFILE_FUNCTION();
         auto it = std::find(m_Layers.begin(), m_Layers.end(), layer);
         if (it != m_Layers.end()) {
             const auto index = it - m_Layers.begin();
@@ -47,6 +52,7 @@ namespace Lavendel
 
     void LayerStack::PopOverlay(Layer* overlay)
     {
+        LV_PROFILE_FUNCTION();
         auto it = std::find(m_Layers.begin(), m_Layers.end(), overlay);
         if (it != m_Layers.end()) {
             overlay->OnDetach();

--- a/Lavendel/src/Lavendel/Log.cpp
+++ b/Lavendel/src/Lavendel/Log.cpp
@@ -8,6 +8,7 @@ namespace Lavendel {
 
     void Log::Init()
     {
+        LV_PROFILE_FUNCTION();
         spdlog::set_pattern("%^[%T] %n: %v%$");
         s_CoreLogger = spdlog::stdout_color_mt("LAVENDEL");
         s_CoreLogger->set_level(spdlog::level::trace);

--- a/Lavendel/src/Lavendel/Renderer/Core/Device.cpp
+++ b/Lavendel/src/Lavendel/Renderer/Core/Device.cpp
@@ -15,6 +15,7 @@ namespace Lavendel {
             const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData,
             void* pUserData)
         {
+            LV_PROFILE_FUNCTION();
             // Safety check: logger might not be initialized yet during early callbacks
             auto coreLogger = ::Lavendel::Log::GetCoreLogger();
             if (coreLogger && coreLogger.get() != nullptr) {
@@ -33,6 +34,7 @@ namespace Lavendel {
             const VkAllocationCallbacks* pAllocator,
             VkDebugUtilsMessengerEXT* pDebugMessenger)
         {
+            LV_PROFILE_FUNCTION();
             auto func = (PFN_vkCreateDebugUtilsMessengerEXT)vkGetInstanceProcAddr(
                 instance,
                 "vkCreateDebugUtilsMessengerEXT");
@@ -51,6 +53,7 @@ namespace Lavendel {
             VkDebugUtilsMessengerEXT debugMessenger,
             const VkAllocationCallbacks* pAllocator)
         {
+            LV_PROFILE_FUNCTION();
             auto func = (PFN_vkDestroyDebugUtilsMessengerEXT)vkGetInstanceProcAddr(
                 instance,
                 "vkDestroyDebugUtilsMessengerEXT");
@@ -63,6 +66,7 @@ namespace Lavendel {
         // class member functions
         GPUDevice::GPUDevice(Window& window) : m_Window{ window }
         {
+            LV_PROFILE_FUNCTION();
             LV_CORE_INFO("Creating GPUDevice...");
             createInstance();
 			setupDebugMessenger(); // validation layers
@@ -74,6 +78,7 @@ namespace Lavendel {
 
         GPUDevice::~GPUDevice()
         {
+            LV_PROFILE_FUNCTION();
             vkDestroyCommandPool(m_Device, m_CommandPool, nullptr);
             vkDestroyDevice(m_Device, nullptr);
 
@@ -88,6 +93,7 @@ namespace Lavendel {
 
         void GPUDevice::createInstance()
         {
+            LV_PROFILE_FUNCTION();
             if (enableValidationLayers && !checkValidationLayerSupport())
             {
                 throw std::runtime_error("validation layers requested, but not available!");
@@ -140,6 +146,7 @@ namespace Lavendel {
 
         void GPUDevice::pickPhysicalDevice()
         {
+            LV_PROFILE_FUNCTION();
             uint32_t deviceCount = 0;
             vkEnumeratePhysicalDevices(m_Instance, &deviceCount, nullptr);
             if (deviceCount == 0)
@@ -171,6 +178,7 @@ namespace Lavendel {
 
         void GPUDevice::createLogicalDevice()
         {
+            LV_PROFILE_FUNCTION();
             QueueFamilyIndices indices = findQueueFamilies(m_PhysicalDevice);
 
             std::vector<VkDeviceQueueCreateInfo> queueCreateInfos;
@@ -224,6 +232,7 @@ namespace Lavendel {
 
         void GPUDevice::createCommandPool()
         {
+            LV_PROFILE_FUNCTION();
             QueueFamilyIndices queueFamilyIndices = findPhysicalQueueFamilies();
 
             VkCommandPoolCreateInfo poolInfo = {};
@@ -239,10 +248,11 @@ namespace Lavendel {
             }
         }
 
-        void GPUDevice::createSurface() { m_Window.createWindowSurface(m_Instance, &m_Surface); }
+        void GPUDevice::createSurface() { LV_PROFILE_FUNCTION(); m_Window.createWindowSurface(m_Instance, &m_Surface); }
 
         bool GPUDevice::isDeviceSuitable(VkPhysicalDevice device)
         {
+            LV_PROFILE_FUNCTION();
             QueueFamilyIndices indices = findQueueFamilies(device);
 
             bool extensionsSupported = checkDeviceExtensionSupport(device);
@@ -264,6 +274,7 @@ namespace Lavendel {
         void GPUDevice::populateDebugMessengerCreateInfo(
             VkDebugUtilsMessengerCreateInfoEXT& createInfo)
         {
+            LV_PROFILE_FUNCTION();
             createInfo = {};
             createInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
             createInfo.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
@@ -277,6 +288,7 @@ namespace Lavendel {
 
         void GPUDevice::setupDebugMessenger()
         {
+            LV_PROFILE_FUNCTION();
             if (!enableValidationLayers) return;
             VkDebugUtilsMessengerCreateInfoEXT createInfo;
             populateDebugMessengerCreateInfo(createInfo);
@@ -289,6 +301,7 @@ namespace Lavendel {
 
         bool GPUDevice::checkValidationLayerSupport()
         {
+            LV_PROFILE_FUNCTION();
             uint32_t layerCount;
             vkEnumerateInstanceLayerProperties(&layerCount, nullptr);
 
@@ -319,6 +332,7 @@ namespace Lavendel {
 
         std::vector<const char*> GPUDevice::getRequiredExtensions()
         {
+            LV_PROFILE_FUNCTION();
             // Get SDL3 required Vulkan instance extensions
             uint32_t sdlExtensionCount = 0;
             const char* const* sdlExtensions = SDL_Vulkan_GetInstanceExtensions(&sdlExtensionCount);
@@ -343,6 +357,7 @@ namespace Lavendel {
 
         void GPUDevice::hasSDLRequiredInstanceExtensions()
         {
+            LV_PROFILE_FUNCTION();
             uint32_t extensionCount = 0;
             vkEnumerateInstanceExtensionProperties(nullptr, &extensionCount, nullptr);
             std::vector<VkExtensionProperties> extensions(extensionCount);
@@ -352,7 +367,7 @@ namespace Lavendel {
             std::unordered_set<std::string> available;
             for (const auto& extension : extensions)
             {
-                LV_CORE_INFO("\t {}", extension.extensionName);
+				LV_CORE_INFO("\t {}", extension.extensionName);
                 available.insert(extension.extensionName);
             }
 
@@ -371,6 +386,7 @@ namespace Lavendel {
 
         bool GPUDevice::checkDeviceExtensionSupport(VkPhysicalDevice device)
         {
+            LV_PROFILE_FUNCTION();
             uint32_t extensionCount;
             vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount, nullptr);
 
@@ -393,6 +409,7 @@ namespace Lavendel {
 
         QueueFamilyIndices GPUDevice::findQueueFamilies(VkPhysicalDevice device)
         {
+            LV_PROFILE_FUNCTION();
             QueueFamilyIndices indices;
 
             uint32_t queueFamilyCount = 0;
@@ -429,6 +446,7 @@ namespace Lavendel {
 
         SwapChainSupportDetails GPUDevice::querySwapChainSupport(VkPhysicalDevice device)
         {
+            LV_PROFILE_FUNCTION();
             SwapChainSupportDetails details;
             vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device, m_Surface, &details.capabilities);
 
@@ -459,6 +477,7 @@ namespace Lavendel {
         VkFormat GPUDevice::findSupportedFormat(
             const std::vector<VkFormat>& candidates, VkImageTiling tiling, VkFormatFeatureFlags features)
         {
+            LV_PROFILE_FUNCTION();
             for (VkFormat format : candidates)
             {
                 VkFormatProperties props;
@@ -479,6 +498,7 @@ namespace Lavendel {
 
         uint32_t GPUDevice::findMemoryType(uint32_t typeFilter, VkMemoryPropertyFlags properties)
         {
+            LV_PROFILE_FUNCTION();
             VkPhysicalDeviceMemoryProperties memProperties;
             vkGetPhysicalDeviceMemoryProperties(m_PhysicalDevice, &memProperties);
             for (uint32_t i = 0; i < memProperties.memoryTypeCount; i++)
@@ -501,6 +521,7 @@ namespace Lavendel {
             VkBuffer& buffer,
             VkDeviceMemory& bufferMemory)
         {
+            LV_PROFILE_FUNCTION();
             VkBufferCreateInfo bufferInfo{};
             bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
             bufferInfo.size = size;
@@ -532,6 +553,7 @@ namespace Lavendel {
 
         VkCommandBuffer GPUDevice::beginSingleTimeCommands()
         {
+            LV_PROFILE_FUNCTION();
             VkCommandBufferAllocateInfo allocInfo{};
             allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
             allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
@@ -551,6 +573,7 @@ namespace Lavendel {
 
         void GPUDevice::endSingleTimeCommands(VkCommandBuffer commandBuffer)
         {
+            LV_PROFILE_FUNCTION();
             vkEndCommandBuffer(commandBuffer);
 
             VkSubmitInfo submitInfo{};
@@ -566,6 +589,7 @@ namespace Lavendel {
 
         void GPUDevice::copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size)
         {
+            LV_PROFILE_FUNCTION();
             VkCommandBuffer commandBuffer = beginSingleTimeCommands();
 
             VkBufferCopy copyRegion{};
@@ -580,6 +604,7 @@ namespace Lavendel {
         void GPUDevice::copyBufferToImage(
             VkBuffer buffer, VkImage image, uint32_t width, uint32_t height, uint32_t layerCount)
         {
+            LV_PROFILE_FUNCTION();
             VkCommandBuffer commandBuffer = beginSingleTimeCommands();
 
             VkBufferImageCopy region{};
@@ -611,6 +636,7 @@ namespace Lavendel {
             VkImage& image,
             VkDeviceMemory& imageMemory)
         {
+            LV_PROFILE_FUNCTION();
             if (vkCreateImage(m_Device, &imageInfo, nullptr, &image) != VK_SUCCESS)
             {
                 throw std::runtime_error("failed to create image!");

--- a/Lavendel/src/Lavendel/Renderer/Core/Device.h
+++ b/Lavendel/src/Lavendel/Renderer/Core/Device.h
@@ -8,7 +8,7 @@ namespace Lavendel {
     namespace RenderAPI {
 
         // Forward declaration to break circular dependency
-        class Window;
+        class LAVENDEL_API Window;
 
         struct SwapChainSupportDetails
         {

--- a/Lavendel/src/Lavendel/Renderer/Core/Swapchain.cpp
+++ b/Lavendel/src/Lavendel/Renderer/Core/Swapchain.cpp
@@ -7,6 +7,7 @@ namespace Lavendel {
         SwapChain::SwapChain(GPUDevice& deviceRef, VkExtent2D windowExtent)
             : m_Device{ deviceRef }, windowExtent{ windowExtent }, m_OldSwapchain{ nullptr }
         {
+            LV_PROFILE_FUNCTION();
             LV_CORE_INFO("Creating Swapchain...");
             init();
         }
@@ -14,6 +15,7 @@ namespace Lavendel {
         SwapChain::SwapChain(GPUDevice& deviceRef, VkExtent2D windowExtent, std::shared_ptr<SwapChain> previous)
             : m_Device{ deviceRef }, windowExtent{ windowExtent }, m_OldSwapchain{ previous }
         {
+            LV_PROFILE_FUNCTION();
             LV_CORE_INFO("Creating Swapchain with old SwapChain...");
             init();
 			m_OldSwapchain = nullptr;
@@ -21,6 +23,7 @@ namespace Lavendel {
 
         void SwapChain::init()
         {
+            LV_PROFILE_FUNCTION();
             createSwapChain();
             createImageViews();
             createRenderPass();
@@ -31,6 +34,7 @@ namespace Lavendel {
 
         SwapChain::~SwapChain()
         {
+            LV_PROFILE_FUNCTION();
             for (auto imageView : swapChainImageViews)
             {
                 vkDestroyImageView(m_Device.device(), imageView, nullptr);
@@ -67,6 +71,7 @@ namespace Lavendel {
 
         VkResult SwapChain::acquireNextImage(uint32_t &imageIndex)
         {
+            LV_PROFILE_FUNCTION();
             vkWaitForFences(
                 m_Device.device(),
                 1,
@@ -88,6 +93,7 @@ namespace Lavendel {
         VkResult SwapChain::submitCommandBuffers(
             const VkCommandBuffer* buffers, uint32_t* imageIndex)
         {
+            LV_PROFILE_FUNCTION();
             if (imagesInFlight[*imageIndex] != VK_NULL_HANDLE)
             {
                 vkWaitForFences(m_Device.device(), 1, &imagesInFlight[*imageIndex], VK_TRUE, UINT64_MAX);
@@ -137,6 +143,7 @@ namespace Lavendel {
 
         void SwapChain::createSwapChain()
         {
+            LV_PROFILE_FUNCTION();
             SwapChainSupportDetails swapChainSupport = m_Device.getSwapChainSupport();
 
             VkSurfaceFormatKHR surfaceFormat = chooseSwapSurfaceFormat(swapChainSupport.formats);
@@ -200,6 +207,7 @@ namespace Lavendel {
 
         void SwapChain::createImageViews()
         {
+            LV_PROFILE_FUNCTION();
             swapChainImageViews.resize(swapChainImages.size());
             for (size_t i = 0; i < swapChainImages.size(); i++)
             {
@@ -224,6 +232,7 @@ namespace Lavendel {
 
         void SwapChain::createRenderPass()
         {
+            LV_PROFILE_FUNCTION();
             VkAttachmentDescription depthAttachment{};
             depthAttachment.format = findDepthFormat();
             depthAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -287,6 +296,7 @@ namespace Lavendel {
 
         void SwapChain::createFramebuffers()
         {
+            LV_PROFILE_FUNCTION();
             swapChainFramebuffers.resize(imageCount());
             for (size_t i = 0; i < imageCount(); i++)
             {
@@ -315,6 +325,7 @@ namespace Lavendel {
 
         void SwapChain::createDepthResources()
         {
+            LV_PROFILE_FUNCTION();
             VkFormat depthFormat = findDepthFormat();
             VkExtent2D swapChainExtent = getSwapChainExtent();
 
@@ -366,6 +377,7 @@ namespace Lavendel {
 
         void SwapChain::createSyncObjects()
         {
+            LV_PROFILE_FUNCTION();
             imageAvailableSemaphores.resize(MAX_FRAMES_IN_FLIGHT);
             renderFinishedSemaphores.resize(MAX_FRAMES_IN_FLIGHT);
             inFlightFences.resize(MAX_FRAMES_IN_FLIGHT);
@@ -394,6 +406,7 @@ namespace Lavendel {
         VkSurfaceFormatKHR SwapChain::chooseSwapSurfaceFormat(
             const std::vector<VkSurfaceFormatKHR>& availableFormats)
         {
+            LV_PROFILE_FUNCTION();
             for (const auto& availableFormat : availableFormats)
             {
                 if (availableFormat.format == VK_FORMAT_B8G8R8A8_SRGB &&
@@ -409,6 +422,7 @@ namespace Lavendel {
         VkPresentModeKHR SwapChain::chooseSwapPresentMode(
             const std::vector<VkPresentModeKHR>& availablePresentModes)
         {
+            LV_PROFILE_FUNCTION();
             /*for (const auto& availablePresentMode : availablePresentModes)
             {
                 if (availablePresentMode == VK_PRESENT_MODE_MAILBOX_KHR)
@@ -424,6 +438,7 @@ namespace Lavendel {
 
         VkExtent2D SwapChain::chooseSwapExtent(const VkSurfaceCapabilitiesKHR& capabilities)
         {
+            LV_PROFILE_FUNCTION();
             if (capabilities.currentExtent.width != std::numeric_limits<uint32_t>::max())
             {
                 return capabilities.currentExtent;
@@ -444,6 +459,7 @@ namespace Lavendel {
 
         VkFormat SwapChain::findDepthFormat()
         {
+            LV_PROFILE_FUNCTION();
             return m_Device.findSupportedFormat(
                 { VK_FORMAT_D32_SFLOAT, VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT },
                 VK_IMAGE_TILING_OPTIMAL,

--- a/Lavendel/src/Lavendel/Renderer/Core/Swapchain.h
+++ b/Lavendel/src/Lavendel/Renderer/Core/Swapchain.h
@@ -5,7 +5,7 @@
 namespace Lavendel {
     namespace RenderAPI {
 
-        class SwapChain
+        class LAVENDEL_API SwapChain
         {
         public:
             static constexpr int MAX_FRAMES_IN_FLIGHT = 2;

--- a/Lavendel/src/Lavendel/Renderer/Model/Model.cpp
+++ b/Lavendel/src/Lavendel/Renderer/Model/Model.cpp
@@ -7,17 +7,20 @@ namespace Lavendel
     {
 		Model::Model(GPUDevice& device, const std::vector<Model::Vertex>& vertices) : m_Device{ device }
         {
+            LV_PROFILE_FUNCTION();
             LV_CORE_INFO("Creating Model...");
             createVertexBuffers(vertices);
         }
         Model::~Model()
         {
+            LV_PROFILE_FUNCTION();
             vkDestroyBuffer(m_Device.device(), m_VertexBuffer, nullptr);
             vkFreeMemory(m_Device.device(), m_VertexBufferMemory, nullptr);
 		}
 
         void Model::createVertexBuffers(const std::vector<Model::Vertex>& vertecies)
         {
+            LV_PROFILE_FUNCTION();
             m_VertexCount = static_cast<uint32_t>(vertecies.size());
 
             if (m_VertexCount < 3)
@@ -43,11 +46,13 @@ namespace Lavendel
 
         void Model::draw(VkCommandBuffer commandBuffer)
         {
+            LV_PROFILE_FUNCTION();
             vkCmdDraw(commandBuffer, m_VertexCount, 1, 0, 0);
 		}
         
         void Model::bind(VkCommandBuffer commandBuffer)
         {
+            LV_PROFILE_FUNCTION();
 			VkBuffer buffers[] = { m_VertexBuffer };
             VkDeviceSize offsets[] = { 0 };
 			vkCmdBindVertexBuffers(commandBuffer, 0, 1, buffers, offsets);
@@ -55,6 +60,7 @@ namespace Lavendel
 
         std::vector<VkVertexInputBindingDescription> Model::Vertex::getBindingDescription()
         {
+            LV_PROFILE_FUNCTION();
             std::vector<VkVertexInputBindingDescription> bindingDescriptions(1);
             bindingDescriptions[0].binding = 0;
             bindingDescriptions[0].stride = sizeof(Vertex);
@@ -64,6 +70,7 @@ namespace Lavendel
 
         std::vector<VkVertexInputAttributeDescription> Model::Vertex::getAttributeDescription()
         {
+            LV_PROFILE_FUNCTION();
             std::vector<VkVertexInputAttributeDescription> attributeDescriptions(2);
 
             attributeDescriptions[0].binding = 0;

--- a/Lavendel/src/Lavendel/Renderer/Model/Model.h
+++ b/Lavendel/src/Lavendel/Renderer/Model/Model.h
@@ -11,7 +11,7 @@ namespace  Lavendel
 {
     namespace RenderAPI
     {
-        class Model
+        class LAVENDEL_API Model
         {
 
 

--- a/Lavendel/src/Lavendel/Renderer/Pipeline/Pipeline.cpp
+++ b/Lavendel/src/Lavendel/Renderer/Pipeline/Pipeline.cpp
@@ -13,6 +13,7 @@ namespace Lavendel {
 
 		Pipeline::~Pipeline()
 		{
+			LV_PROFILE_FUNCTION();
 			
 			vkDestroyShaderModule(m_Device.device(), fragShaderModule, nullptr);
 			vkDestroyShaderModule(m_Device.device(), vertShaderModule, nullptr);
@@ -22,23 +23,26 @@ namespace Lavendel {
 		Pipeline::Pipeline(GPUDevice& device, const std::string& vertFilepath, const std::string& fragFilePath, const PipelineConfigInfo& configInfo) 
 			: m_Device{ device }
 		{
+			LV_PROFILE_FUNCTION();
 			LV_CORE_INFO("Creating Pipeline...");
 			createGraphicsPipeline(vertFilepath, fragFilePath, configInfo);
 		}
 
 		void Pipeline::bind(VkCommandBuffer commandBuffer)
 		{
+			LV_PROFILE_FUNCTION();
 			vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, graphicsPipeline);
 		}
 
 		std::vector<char> Pipeline::readFile(const std::string& filepath)
 		{
-			std::ifstream file(filepath, std::ios::ate | std::ios::binary);
+			LV_PROFILE_FUNCTION();
+			auto file = std::ifstream(filepath, std::ios::ate | std::ios::binary);
 
 			if (!file)
 			{
 				LV_CORE_ERROR("Failed to open file: {}", filepath);
-				throw std::runtime_error("Failed to open file: " + filepath);  
+				throw std::runtime_error("Failed to open file: " + filepath);
 			}
 
 			size_t fileSize = (size_t)file.tellg();
@@ -53,6 +57,7 @@ namespace Lavendel {
 
 		void Pipeline::createGraphicsPipeline(const std::string& vertShaderPath, const std::string& fragShaderPath, const PipelineConfigInfo& configInfo)
 		{
+			LV_PROFILE_FUNCTION();
 			auto vertCode = readFile(vertShaderPath);
 			auto fragCode = readFile(fragShaderPath);
 			
@@ -121,6 +126,7 @@ namespace Lavendel {
 
 		void Pipeline::createShaderModule(const std::vector<char>& code, VkShaderModule* shaderModule) 
 		{
+			LV_PROFILE_FUNCTION();
 			VkShaderModuleCreateInfo createInfo{};
 			createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
 			createInfo.codeSize = code.size();
@@ -135,6 +141,7 @@ namespace Lavendel {
 
 		void Pipeline::defaultPipelineConfigInfo(PipelineConfigInfo& configInfo)
 		{
+			LV_PROFILE_FUNCTION();
 			// Input Assembly
 
 			configInfo.inputAssemblyInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;

--- a/Lavendel/src/Lavendel/Renderer/Pipeline/Pipeline.h
+++ b/Lavendel/src/Lavendel/Renderer/Pipeline/Pipeline.h
@@ -5,7 +5,7 @@ namespace Lavendel {
 	namespace RenderAPI {
 
 		// Forward declaration to break circular dependency
-		class GPUDevice;
+		class LAVENDEL_API GPUDevice;
 
 		struct PipelineConfigInfo
 		{
@@ -31,7 +31,7 @@ namespace Lavendel {
 			bool isExplosive = false;
 			bool isLaser = false;
 		};
-		class LAVENDEL_API Pipeline
+		class LAVENDEL_API LAVENDEL_API Pipeline
 		{
 		public:
 			Pipeline(GPUDevice& device,

--- a/Lavendel/src/Lavendel/Renderer/Renderer.cpp
+++ b/Lavendel/src/Lavendel/Renderer/Renderer.cpp
@@ -18,6 +18,7 @@ namespace Lavendel {
 
 		Renderer::Renderer(Window& window) : m_Window(window)
 		{
+			LV_PROFILE_FUNCTION();
 			LV_CORE_INFO("Initializing Renderer...");
 
 			m_Device = std::make_shared<GPUDevice>(m_Window);
@@ -29,11 +30,13 @@ namespace Lavendel {
 
 		Renderer::~Renderer()
 		{
+			LV_PROFILE_FUNCTION();
 			vkDestroyPipelineLayout(m_Device->device(), m_PipelineLayout, nullptr);
 		}
 
 		void Renderer::createPipelineLayout()
 		{
+			LV_PROFILE_FUNCTION();
 			VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
 			pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
 			pipelineLayoutInfo.setLayoutCount = 0;
@@ -49,6 +52,7 @@ namespace Lavendel {
 
 		void Renderer::createPipeline()
 		{
+			LV_PROFILE_FUNCTION();
 			PipelineConfigInfo pipelineConfig{};
 			Lavendel::RenderAPI::Pipeline::defaultPipelineConfigInfo(pipelineConfig);
 			pipelineConfig.renderPass = m_SwapChain->getRenderPass();
@@ -62,6 +66,7 @@ namespace Lavendel {
 
 		void Renderer::recreateSwapChain()
 		{
+			LV_PROFILE_FUNCTION();
 			auto extent = m_Window.getExtent();
 			while (extent.width == 0 || extent.height == 0)
 			{
@@ -91,6 +96,7 @@ namespace Lavendel {
 
 		void Renderer::loadModels()
 		{
+			LV_PROFILE_FUNCTION();
 			std::vector<Model::Vertex> vertices = {
 				{{0.0f, -0.5f}, {1.0f, 0.0f, 0.0f}},
 				{{ -0.5f, 0.5f }, {0.0f, 1.0f, 0.0f}},
@@ -101,6 +107,7 @@ namespace Lavendel {
 
 		void Renderer::createCommandBuffers()
 		{
+			LV_PROFILE_FUNCTION();
 			m_CommandBuffers.resize(m_SwapChain->imageCount());
 
 			VkCommandBufferAllocateInfo allocInfo{};
@@ -118,6 +125,7 @@ namespace Lavendel {
 
 		void Renderer::freeCommandBuffers()
 		{
+			LV_PROFILE_FUNCTION();
 			vkFreeCommandBuffers(
 				m_Device->device(),
 				m_Device->getCommandPool(),
@@ -128,6 +136,7 @@ namespace Lavendel {
 
 		void Renderer::recordCommandBuffer(int imageIndex)
 		{
+			LV_PROFILE_FUNCTION();
 			VkCommandBufferBeginInfo beginInfo{};
 			beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
 			if (vkBeginCommandBuffer(m_CommandBuffers[imageIndex], &beginInfo) != VK_SUCCESS)
@@ -176,6 +185,7 @@ namespace Lavendel {
 			{
 				for (Layer* layer : *m_LayerStack)
 				{
+					LV_PROFILE_SCOPE("Layer::OnRender Call");
 					// Pass the command buffer as a void* to avoid including Vulkan headers in Layer.h
 					layer->OnRender(reinterpret_cast<void*>(m_CommandBuffers[imageIndex]));
 				}
@@ -191,6 +201,7 @@ namespace Lavendel {
 
 		void Renderer::drawFrame()
 		{
+			LV_PROFILE_FUNCTION();
 			uint32_t imageIndex;
 			auto result = m_SwapChain->acquireNextImage(imageIndex);
 
@@ -224,6 +235,7 @@ namespace Lavendel {
 
 		void Renderer::renderImGui(VkCommandBuffer commandBuffer)
 		{
+			LV_PROFILE_FUNCTION();
 			// This method is called during recordCommandBuffer when rendering the ImGuiLayer.
 			// By separating ImGui rendering into its own method and calling it from the layer
 			// iteration process, we ensure ImGui respects the layer stack order and renders

--- a/Lavendel/src/Lavendel/Renderer/Renderer.h
+++ b/Lavendel/src/Lavendel/Renderer/Renderer.h
@@ -16,7 +16,7 @@ namespace Lavendel
 
 	namespace RenderAPI
 	{
-		class LAVENDEL_API Renderer
+		class LAVENDEL_API LAVENDEL_API Renderer
 		{
 		public:
 			Renderer(Window& window);

--- a/Lavendel/src/Lavendel/Renderer/Window.cpp
+++ b/Lavendel/src/Lavendel/Renderer/Window.cpp
@@ -13,17 +13,20 @@ namespace Lavendel {
         Window::Window(int width, int height, const std::string& title, bool bResizable)
             : m_Width(width), m_Height(height), m_Title(title), m_bResizable(bResizable)
         {
+            LV_PROFILE_FUNCTION();
             LV_CORE_INFO("Creating Window...");
             Init(width, height, title, bResizable);
         }
 
         Window::~Window()
         {
+            LV_PROFILE_FUNCTION();
             Shutdown();
         }
 
         void Window::Init(int width, int height, const std::string& title, bool bResizable)
         {
+            LV_PROFILE_FUNCTION();
             m_Width = width;
             m_Height = height;
             m_Title = title;
@@ -57,6 +60,7 @@ namespace Lavendel {
 
         void Window::Shutdown()
         {
+            LV_PROFILE_FUNCTION();
             if (m_Window)
             {
                 SDL_DestroyWindow(m_Window);
@@ -66,6 +70,7 @@ namespace Lavendel {
 
         void Window::createWindowSurface(VkInstance instance, VkSurfaceKHR* surface)
         {
+            LV_PROFILE_FUNCTION();
             if (!SDL_Vulkan_CreateSurface(m_Window, instance, nullptr, surface))
             {
                 LV_CORE_ERROR("Failed to create Vulkan surface: {}", SDL_GetError());
@@ -75,17 +80,19 @@ namespace Lavendel {
 
         bool Window::ShouldClose()
         {
+            LV_PROFILE_FUNCTION();
             SDL_Event event;
             while (SDL_PollEvent(&event))
             {
+                LV_PROFILE_SCOPE("Window::ShouldClose PollEvent Loop");
                 if (event.type == SDL_EVENT_QUIT)
                     return true;
 
                 if (event.type == SDL_EVENT_WINDOW_RESIZED)
                 {
-					m_bFrameBufferResized = true;
-					m_Width = event.window.data1;
-					m_Height = event.window.data2;
+				m_bFrameBufferResized = true;
+				m_Width = event.window.data1;
+				m_Height = event.window.data2;
                 }
 
                 if (event.type == SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED)

--- a/Lavendel/src/Lavendel/Utils/Profiling/Instrumentor.h
+++ b/Lavendel/src/Lavendel/Utils/Profiling/Instrumentor.h
@@ -13,6 +13,7 @@
 // You will probably want to macro-fy this, to switch on/off easily and use things like __FUNCSIG__ for the profile name.
 //
 #pragma once
+#include "lvpch.h"
 
 #include <string>
 #include <chrono>
@@ -33,7 +34,7 @@ struct InstrumentationSession
     std::string Name;
 };
 
-class Instrumentor
+class LAVENDEL_API Instrumentor
 {
 private:
     InstrumentationSession* m_CurrentSession;
@@ -133,3 +134,14 @@ private:
     std::chrono::time_point<std::chrono::high_resolution_clock> m_StartTimepoint;
     bool m_Stopped;
 };
+
+
+
+
+    #define LV_PROFILE_BEGIN_SESSION(name, filepath) ::Instrumentor::Get().BeginSession(name, filepath)
+    #define LV_PROFILE_END_SESSION() ::Instrumentor::Get().EndSession()
+    // Two-level macro to ensure __LINE__ is expanded before token pasting on all compilers
+    #define LV_CONCAT_INTERNAL(x, y) x##y
+    #define LV_CONCAT(x, y) LV_CONCAT_INTERNAL(x, y)
+    #define LV_PROFILE_SCOPE(name) ::InstrumentationTimer LV_CONCAT(timer, __LINE__)(name)
+    #define LV_PROFILE_FUNCTION() LV_PROFILE_SCOPE(__FUNCSIG__)

--- a/Lavendel/src/lvpch.cpp
+++ b/Lavendel/src/lvpch.cpp
@@ -1,1 +1,2 @@
 #include "lvpch.h"
+

--- a/Lavendel/src/lvpch.h
+++ b/Lavendel/src/lvpch.h
@@ -32,3 +32,4 @@
 // self
 #include "Lavendel/Log.h"
 #include "Lavendel/Core.h"
+#include "Lavendel/Utils/Profiling/Instrumentor.h"

--- a/Sandbox/src/Solution.cpp
+++ b/Sandbox/src/Solution.cpp
@@ -3,13 +3,15 @@
 class ExampleLayer : public Lavendel::Layer
 {
 	public:
-	ExampleLayer() : Layer("Example") {}
+	ExampleLayer() : Layer("Example") { LV_PROFILE_FUNCTION(); }
 	void OnUpdate() override
 	{
+		LV_PROFILE_FUNCTION();
 		//LV_CORE_INFO("ExampleLayer::Update");
 	}
 	void OnEvent(Lavendel::Event& event) override
 	{
+		LV_PROFILE_FUNCTION();
 		LV_CORE_INFO("{0}", event.ToString());
 	}
 }; 
@@ -21,14 +23,16 @@ class Sandbox : public  Lavendel::Application
 public: 
 		Sandbox() 
 		{
+			LV_PROFILE_FUNCTION();
 			PushLayer(new ExampleLayer());
 			PushLayer(new Lavendel::ImGuiLayer());
 		}
-		~Sandbox() {}
+		~Sandbox() { LV_PROFILE_FUNCTION(); }
 };
 
 
 Lavendel::Application* Lavendel::CreateApplication()
 {
+	LV_PROFILE_FUNCTION();
 	return new Sandbox();
 }


### PR DESCRIPTION
This pull request introduces profiling instrumentation throughout the Lavendel engine to facilitate performance analysis and debugging. The main changes include adding profiling macros to constructors, destructors, and key methods across core classes, integrating profiling session management into the application entry point, and relocating the `Instrumentor.h` header to a new directory. Additionally, several classes have been updated to use the `LAVENDEL_API` macro for improved symbol export. These changes are organized below by theme:

**Profiling Instrumentation:**

* Added `LV_PROFILE_FUNCTION()` and `LV_PROFILE_SCOPE()` macros to constructors, destructors, event handlers, and main loops in `Application`, `ImGuiLayer`, `ImGuiRenderer`, `DemoWidget`, `Layer`, `LayerStack`, and `GPUDevice` to enable detailed function-level and scope-level profiling. [[1]](diffhunk://#diff-586b061d2536927fcd6aaf5bba36e6cb0c82363c673279cee3f5fbdced8773baR14-L32) [[2]](diffhunk://#diff-586b061d2536927fcd6aaf5bba36e6cb0c82363c673279cee3f5fbdced8773baR43-R69) [[3]](diffhunk://#diff-586b061d2536927fcd6aaf5bba36e6cb0c82363c673279cee3f5fbdced8773baR84) [[4]](diffhunk://#diff-586b061d2536927fcd6aaf5bba36e6cb0c82363c673279cee3f5fbdced8773baR93) [[5]](diffhunk://#diff-586b061d2536927fcd6aaf5bba36e6cb0c82363c673279cee3f5fbdced8773baR107-R111) [[6]](diffhunk://#diff-0f4e6c763166d6920d57e46a35b33ed2462100c3e781f6eea6da10c03eb52697R18-R30) [[7]](diffhunk://#diff-0f4e6c763166d6920d57e46a35b33ed2462100c3e781f6eea6da10c03eb52697R67) [[8]](diffhunk://#diff-0f4e6c763166d6920d57e46a35b33ed2462100c3e781f6eea6da10c03eb52697R76) [[9]](diffhunk://#diff-0f4e6c763166d6920d57e46a35b33ed2462100c3e781f6eea6da10c03eb52697R85-R92) [[10]](diffhunk://#diff-0f4e6c763166d6920d57e46a35b33ed2462100c3e781f6eea6da10c03eb52697R105-R127) [[11]](diffhunk://#diff-1c1dc1dff0279a85628a28c8202b57c81e65eca48b454e21eef0488a736b5953R12-R17) [[12]](diffhunk://#diff-1c1dc1dff0279a85628a28c8202b57c81e65eca48b454e21eef0488a736b5953R80) [[13]](diffhunk://#diff-1c1dc1dff0279a85628a28c8202b57c81e65eca48b454e21eef0488a736b5953R96-R110) [[14]](diffhunk://#diff-bf5bcb9b223ae2d3b90fedaf7668508e1bf4d514e22427ea883d1df00f270ba6R8-R19) [[15]](diffhunk://#diff-3ff5a602cbaeeb79c336d74c3f76fa2a8bcb1cbdeb134741409cb40af35646e1R12-R17) [[16]](diffhunk://#diff-3ff5a602cbaeeb79c336d74c3f76fa2a8bcb1cbdeb134741409cb40af35646e1R26-R41) [[17]](diffhunk://#diff-3ff5a602cbaeeb79c336d74c3f76fa2a8bcb1cbdeb134741409cb40af35646e1R55) [[18]](diffhunk://#diff-242c20edd39618888152d2d8d81539bfb93c57e30ec956e7bf9302a56401aaa0R11) [[19]](diffhunk://#diff-a20b9231b786bc4f14667980538f5a74f2cdd5718559809227712c0eda47f005R18) [[20]](diffhunk://#diff-a20b9231b786bc4f14667980538f5a74f2cdd5718559809227712c0eda47f005R37) [[21]](diffhunk://#diff-a20b9231b786bc4f14667980538f5a74f2cdd5718559809227712c0eda47f005R56) [[22]](diffhunk://#diff-a20b9231b786bc4f14667980538f5a74f2cdd5718559809227712c0eda47f005R69) [[23]](diffhunk://#diff-a20b9231b786bc4f14667980538f5a74f2cdd5718559809227712c0eda47f005R81) [[24]](diffhunk://#diff-a20b9231b786bc4f14667980538f5a74f2cdd5718559809227712c0eda47f005R96) [[25]](diffhunk://#diff-a20b9231b786bc4f14667980538f5a74f2cdd5718559809227712c0eda47f005R149) [[26]](diffhunk://#diff-a20b9231b786bc4f14667980538f5a74f2cdd5718559809227712c0eda47f005R181) [[27]](diffhunk://#diff-a20b9231b786bc4f14667980538f5a74f2cdd5718559809227712c0eda47f005R235)

* Integrated profiling session management into `main()` in `Entrypoint.h`, including startup, runtime, and shutdown sessions using `LV_PROFILE_BEGIN_SESSION` and `LV_PROFILE_END_SESSION`.

**File Structure and API Improvements:**

* Moved `Instrumentor.h` from `src/Lavendel/Core/Profiling/` to `src/Lavendel/Utils/Profiling/` to better reflect its utility nature.
* Added the `LAVENDEL_API` macro to `ImGuiLayer`, `ImGuiRenderer`, and `DemoWidget` class declarations for proper symbol export in shared library builds. [[1]](diffhunk://#diff-f88db2574109bc95830ec60a9594327a1fb7abc9180bd8fe2930fbd74ca90337L15-R15) [[2]](diffhunk://#diff-fecac99dd3af00c3264bf1f0c0f519978537fca09901ad24301ced9456600e14L21-R21) [[3]](diffhunk://#diff-83c37d44a7146ef07ccbe08a7a346f44f1859ee56020e67f76825d05d81624a0L7-R7)

**Miscellaneous:**

* Included `lvpch.h` in `Entrypoint.h` for precompiled header usage.

These changes collectively enhance the engine's profiling capabilities and maintainability.add profiling through the chernos instrumentor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added performance profiling instrumentation across application lifecycle for runtime analysis.

* **Bug Fixes**
  * Re-enabled event dispatch flow through the layer stack.
  * Enhanced layer cleanup to properly invoke lifecycle callbacks on removal.
  * Added defensive vertex count validation.

* **Chores**
  * Updated API symbol exports for improved library visibility.
  * Reorganized profiling module structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->